### PR TITLE
Reformatted links to standardized display text format

### DIFF
--- a/01-chat-models/chat-models-mistral-ai/README.md
+++ b/01-chat-models/chat-models-mistral-ai/README.md
@@ -41,7 +41,7 @@ The application relies on the Mistral AI API for providing LLMs.
 
 ### Create a Mistral AI account
 
-Visit [https://console.mistral.ai](console.mistral.ai) and sign up for a new account.
+Visit [console.mistral.ai](https://console.mistral.ai) and sign up for a new account.
 You can choose the "Experiment" plan, which gives you access to the Mistral APIs for free.
 
 ### Configure API Key

--- a/01-chat-models/chat-models-multiple-providers/README.md
+++ b/01-chat-models/chat-models-multiple-providers/README.md
@@ -12,7 +12,7 @@ The application relies on the OpenAI API for providing LLMs.
 
 ### Create an OpenAI account
 
-Visit [https://platform.openai.com](platform.openai.com) and sign up for a new account.
+Visit [platform.openai.com](https://platform.openai.com) and sign up for a new account.
 
 ### Configure API Key
 
@@ -30,7 +30,7 @@ The application relies on the Mistral AI API for providing LLMs.
 
 ### Create a Mistral AI account
 
-Visit [https://console.mistral.ai](console.mistral.ai) and sign up for a new account.
+Visit [console.mistral.ai](https://console.mistral.ai) and sign up for a new account.
 You can choose the "Experiment" plan, which gives you access to the Mistral APIs for free.
 
 ### Configure API Key

--- a/01-chat-models/chat-models-openai/README.md
+++ b/01-chat-models/chat-models-openai/README.md
@@ -41,7 +41,7 @@ The application relies on the OpenAI API for providing LLMs.
 
 ### Create an OpenAI account
 
-Visit [https://platform.openai.com](platform.openai.com) and sign up for a new account.
+Visit [platform.openai.com](https://platform.openai.com) and sign up for a new account.
 
 ### Configure API Key
 

--- a/02-prompts/prompts-basics-openai/README.md
+++ b/02-prompts/prompts-basics-openai/README.md
@@ -8,7 +8,7 @@ The application relies on the OpenAI API for providing LLMs.
 
 ### Create an OpenAI account
 
-Visit [https://platform.openai.com](platform.openai.com) and sign up for a new account.
+Visit [platform.openai.com](https://platform.openai.com) and sign up for a new account.
 
 ### Configure API Key
 

--- a/02-prompts/prompts-messages-openai/README.md
+++ b/02-prompts/prompts-messages-openai/README.md
@@ -8,7 +8,7 @@ The application relies on the OpenAI API for providing LLMs.
 
 ### Create an OpenAI account
 
-Visit [https://platform.openai.com](platform.openai.com) and sign up for a new account.
+Visit [platform.openai.com](https://platform.openai.com) and sign up for a new account.
 
 ### Configure API Key
 

--- a/02-prompts/prompts-templates-openai/README.md
+++ b/02-prompts/prompts-templates-openai/README.md
@@ -8,7 +8,7 @@ The application relies on the OpenAI API for providing LLMs.
 
 ### Create an OpenAI account
 
-Visit [https://platform.openai.com](platform.openai.com) and sign up for a new account.
+Visit [platform.openai.com](https://platform.openai.com) and sign up for a new account.
 
 ### Configure API Key
 

--- a/03-structured-output/structured-output-openai/README.md
+++ b/03-structured-output/structured-output-openai/README.md
@@ -8,7 +8,7 @@ The application relies on the OpenAI API for providing LLMs.
 
 ### Create an OpenAI account
 
-Visit [https://platform.openai.com](platform.openai.com) and sign up for a new account.
+Visit [platform.openai.com](https://platform.openai.com) and sign up for a new account.
 
 ### Configure API Key
 

--- a/04-multimodality/multimodality-openai/README.md
+++ b/04-multimodality/multimodality-openai/README.md
@@ -8,7 +8,7 @@ The application relies on the OpenAI API for providing LLMs.
 
 ### Create an OpenAI account
 
-Visit [https://platform.openai.com](platform.openai.com) and sign up for a new account.
+Visit [platform.openai.com](https://platform.openai.com) and sign up for a new account.
 
 ### Configure API Key
 

--- a/05-function-calling/function-calling-mistral-ai/README.md
+++ b/05-function-calling/function-calling-mistral-ai/README.md
@@ -8,7 +8,7 @@ The application relies on the Mistral AI API for providing LLMs.
 
 ### Create a Mistral AI account
 
-Visit [https://console.mistral.ai](console.mistral.ai) and sign up for a new account.
+Visit [console.mistral.ai](https://console.mistral.ai) and sign up for a new account.
 You can choose the "Experiment" plan, which gives you access to the Mistral APIs for free.
 
 ### Configure API Key

--- a/05-function-calling/function-calling-openai/README.md
+++ b/05-function-calling/function-calling-openai/README.md
@@ -8,7 +8,7 @@ The application relies on the OpenAI API for providing LLMs.
 
 ### Create an OpenAI account
 
-Visit [https://platform.openai.com](platform.openai.com) and sign up for a new account.
+Visit [platform.openai.com](https://platform.openai.com) and sign up for a new account.
 
 ### Configure API Key
 

--- a/06-embedding-models/embedding-models-mistral-ai/README.md
+++ b/06-embedding-models/embedding-models-mistral-ai/README.md
@@ -24,7 +24,7 @@ The application relies on the Mistral AI API for providing LLMs.
 
 ### Create a Mistral AI account
 
-Visit [https://console.mistral.ai](console.mistral.ai) and sign up for a new account.
+Visit [console.mistral.ai](https://console.mistral.ai) and sign up for a new account.
 You can choose the "Experiment" plan, which gives you access to the Mistral APIs for free.
 
 ### Configure API Key

--- a/06-embedding-models/embedding-models-openai/README.md
+++ b/06-embedding-models/embedding-models-openai/README.md
@@ -24,7 +24,7 @@ The application relies on the OpenAI API for providing LLMs.
 
 ### Create an OpenAI account
 
-Visit [https://platform.openai.com](platform.openai.com) and sign up for a new account.
+Visit [platform.openai.com](https://platform.openai.com) and sign up for a new account.
 
 ### Configure API Key
 

--- a/11-image-models/image-models-openai/README.md
+++ b/11-image-models/image-models-openai/README.md
@@ -25,7 +25,7 @@ The application relies on the OpenAI API for providing LLMs.
 
 ### Create an OpenAI account
 
-Visit [https://platform.openai.com](platform.openai.com) and sign up for a new account.
+Visit [platform.openai.com](https://platform.openai.com) and sign up for a new account.
 
 ### Configure API Key
 

--- a/12-audio-models/audio-models-speech-openai/README.md
+++ b/12-audio-models/audio-models-speech-openai/README.md
@@ -24,7 +24,7 @@ The application relies on the OpenAI API for providing LLMs.
 
 ### Create an OpenAI account
 
-Visit [https://platform.openai.com](platform.openai.com) and sign up for a new account.
+Visit [platform.openai.com](https://platform.openai.com) and sign up for a new account.
 
 ### Configure API Key
 

--- a/12-audio-models/audio-models-transcription-openai/README.md
+++ b/12-audio-models/audio-models-transcription-openai/README.md
@@ -24,7 +24,7 @@ The application relies on the OpenAI API for providing LLMs.
 
 ### Create an OpenAI account
 
-Visit [https://platform.openai.com](platform.openai.com) and sign up for a new account.
+Visit [platform.openai.com](https://platform.openai.com) and sign up for a new account.
 
 ### Configure API Key
 


### PR DESCRIPTION
# PR Summary
This PR reformats markdown links to improve readability and consistency across the project. Links in the format `[https://example.com](text)` are now standardized to `[text](https://example.com)` in order to resolve broken links.